### PR TITLE
add securecall to blocked functions, remove ForceQuit

### DIFF
--- a/WeakAuras/WeakAuras.lua
+++ b/WeakAuras/WeakAuras.lua
@@ -402,7 +402,7 @@ local blockedFunctions = {
   SetBindingMacro = true,
   GuildDisband = true,
   GuildUninvite = true,
-  ForceQuit = true,
+  securecall = true,
 }
 
 local overrideFunctions = {


### PR DESCRIPTION
`securecall` can be used to break out of the environment. `ForceQuit` has been protected for some time now and can only be called from Blizzard code.